### PR TITLE
change stationary break force

### DIFF
--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -59,7 +59,7 @@ class Controller(object):
         brake = 0 
         if linear_vel == 0 and current_vel < 0.1:   
             throttle = 0
-            brake = 400 # Nm - to hold the car in place if we are stopped at a light. Acceleration -1m/s^2
+            brake = 700 # Nm - to hold the car in place if we are stopped at a light. Acceleration -1m/s^2
 
         elif throttle < .1 and vel_error < 0:
             throttle = 0 


### PR DESCRIPTION
There is a note from Udacity about that:

"In the walkthrough, only 400 Nm of torque is applied to hold the vehicle stationary. This turns out to be slightly less than the amount of force needed, and Carla will roll forward with only 400Nm of torque. To prevent Carla from moving you should apply approximately 700 Nm of torque."